### PR TITLE
Replace onKey with dispatch signal

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@ class PBatch {
 	constructor(loader, opts) {
 		opts = Object.assign({
 			maxBatchSize: Infinity,
-			onKey: () => this._batch.length === 1 && process.nextTick(() => this.dispatch())
+			dispatchSignal: fn => process.nextTick(fn)
 		}, opts);
 
 		this.loader = loader;
 		this.maxBatchSize = opts.maxBatchSize;
-		this.onKey = opts.onKey;
+		this.dispatchSignal = opts.dispatchSignal;
 		this._batch = [];
 		this._promisesQueue = [];
 	}
@@ -53,7 +53,9 @@ class PBatch {
 				return this.dispatch();
 			}
 
-			this.onKey(key);
+			if (this._batch.length === 1) {
+				this.dispatchSignal(() => this.dispatch());
+			}
 		});
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -52,13 +52,14 @@ Default: `Infinity`
 
 Maximum batch size.
 
-##### onKey
+##### dispatchSignal
 
 Type: `Function`<br>
+Default: `fn => process.nextTick(fn)`
 
-Executed after each key put in batch. By default schedules `batch.dispatch()` call on `process.nextTick` (if batch is not empty already).
+Executed after first key put in batch. It should call it's first argument, when it is time for dispatching.
 
-Useful, if you need to wait constant time after last key batching (for ex.).
+Useful, if you need to wait constant time after last key batching for ex.
 
 ### batch
 

--- a/test.js
+++ b/test.js
@@ -56,10 +56,10 @@ test('dispatch method', async t => {
 	t.deepEqual(results, [[1, 2], [3]]);
 });
 
-test('onKey', async t => {
+test('dispatchSignal', async t => {
 	const results = [];
 	const pBatch = new PBatch(keys => results.push(keys), {
-		onKey: () => pBatch.dispatch()
+		dispatchSignal: fn => fn()
 	});
 	await Promise.all([pBatch.add(1), pBatch.add(2)]);
 


### PR DESCRIPTION
This is attempt to replace `onKey` with `dispatchSignal`.

Closes #2

------

https://github.com/facebook/dataloader/issues/58